### PR TITLE
Update readme with submodules instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Open source engine implementation of Stronghold by Firefly Studios. This project
 ![Imgur](https://i.imgur.com/jWMp8Qx.png)
 
 ##  Building
+After cloning the repository, make sure to run `git submodule init` and `git submodule update` to fetch [cxxopts](https://github.com/jarro2783/cxxopts).
+
 Run `cmake` in the build directory.  
 Sourcehold depends on the following libraries:
 * SDL2


### PR DESCRIPTION
Nothing in the readme mentioned that you needed to initialize a submodule to build the project. Added it now.

Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>