### PR TITLE
Add ability to release mouse from window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/*
 cmake-build-debug/*
 .idea
+.vscode

--- a/src/Rendering/Display.cpp
+++ b/src/Rendering/Display.cpp
@@ -52,6 +52,7 @@ void Display::Open(const std::string &title, int width, int height, int index, b
 
     delete [] displayBounds;
 
+    this->nograb = nograb;
     if(!nograb) {
         SDL_SetWindowGrab(window, SDL_TRUE);
     }
@@ -83,6 +84,18 @@ void Display::EndTimer() {
     timer = ntimer;
     if(delta < 1000 / FRAMES_PER_SECOND) {
         SDL_Delay((1000 / FRAMES_PER_SECOND) - delta);
+    }
+}
+
+void Display::GrabMouse() {
+    if(!nograb && SDL_GetWindowGrab(window) == SDL_FALSE) {
+        SDL_SetWindowGrab(window, SDL_TRUE);
+    }
+}
+
+void Display::ReleaseMouse() {
+    if(SDL_GetWindowGrab(window) == SDL_TRUE) {
+        SDL_SetWindowGrab(window, SDL_FALSE);
     }
 }
 

--- a/src/Rendering/Display.h
+++ b/src/Rendering/Display.h
@@ -33,17 +33,19 @@ namespace Sourcehold
                 const int FRAMES_PER_SECOND = 60;
                 uint32_t timer = 0;
                 int frame = 0;
-                bool open = false, fullscreen = false;
+                bool open = false, fullscreen = false, nograb = false;
                 SDL_Window *window;
             public:
                 Display();
                 Display(const Display&) = delete;
                 ~Display();
 
-            void Open(const std::string &title, int width, int height, int index = 0, bool fullscreen = false, bool noborder = false, bool nograb = false);
+                void Open(const std::string &title, int width, int height, int index = 0, bool fullscreen = false, bool noborder = false, bool nograb = false);
                 void ToggleFullscreen();
                 void StartTimer();
                 void EndTimer();
+                void GrabMouse();
+                void ReleaseMouse();
 
                 bool IsOpen();
                 uint32_t GetTicks();

--- a/src/Rendering/Renderer.cpp
+++ b/src/Rendering/Renderer.cpp
@@ -22,8 +22,6 @@ void Renderer::Init(SDL_Window *window) {
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
 //    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
 
-    SDL_SetWindowGrab(window, SDL_TRUE);
-
     /* Window size */
     SDL_AddEventWatch(ResizeEventWatcher, static_cast<void*>(this));
     SDL_GetWindowSize(window, &width, &height);

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -271,6 +271,7 @@ void World::onEventReceive(Keyboard &keyEvent) {
             else manager->ZoomIn();
             break;
         case SDLK_TAB: menubarShown = !menubarShown; break;
+        case SDLK_ESCAPE: manager->ReleaseMouse(); break;
         default: break;
         }
     }else if(keyEvent.GetType() == KEYBOARD_KEYUP) {
@@ -296,6 +297,10 @@ void World::onEventReceive(Mouse &mouseEvent) {
             rmbPressed = SDL_GetTicks();
             mouseX = mouseEvent.GetPosX();
             mouseY = mouseEvent.GetPosY();
+        }
+
+        if(mouseEvent.LmbDown()) {
+            manager->GrabMouse();
         }
     }else if(mouseEvent.GetType() == MOUSE_BUTTONUP) {
         if(mouseEvent.RmbUp()) {


### PR DESCRIPTION
- If the mouse is grabbed and contained inside the window you can now press the `Escape` key to release it.
- If you left click on the window the mosue is grabbed again.
- If you use the `nograb` option the mouse will never be grabbed.

This PR also fixes the `nograb` option.